### PR TITLE
feat: 新增顶部品牌标题栏，展示站点 Logo 与名称

### DIFF
--- a/docs/superpowers/specs/2026-07-09-site-header-brand-design.md
+++ b/docs/superpowers/specs/2026-07-09-site-header-brand-design.md
@@ -1,0 +1,75 @@
+# 设计文档：LuminaPlus 顶部品牌 Header
+
+- 日期：2026-07-09
+- 状态：已批准，待实现
+- 目标：在页面顶部新增一条 sticky 标题栏，展示站点 **Logo + 名称**，滚动时背景毛玻璃虚化；可在主题管理页开关与自定义。
+
+## 背景与动机
+
+LuminaPlus 主题当前顶部没有独立的品牌栏，首页内容（节点概览 + 网格）直接从顶部开始，右上角仅有一个悬浮控件球（切换视图 / 主题 / 后台）。站长缺少一个展示自己站点名称与 Logo 的位置。参考 `komari-theme-emerald` 的 `Header.vue`，它用一条 sticky 标题栏承载 `favicon + sitename`。
+
+## 数据来源（已核实 Komari 后端源码）
+
+- **Logo**：Komari 后台上传的图标即站点 favicon。后端将其存于 `./data/favicon.ico`，通过固定端点 **`/favicon.ico`** 对外提供（见 `web/public/public.go` 的 favicon 优先策略）。因此主题默认直接引用 `/favicon.ico` 即可拿到站长上传的 Logo。
+- **站点名**：`/api/public` 返回的 `sitename` 字段，前端已有 `usePublicConfig()` 提供（`config.sitename`）。
+- `/api/public` **没有**单独的 logo 字段——emerald 也是复用 favicon，本方案一致。
+- **自定义 Logo URL**（可选）：站长可在主题管理页填任意图片地址；留空时回退 `/favicon.ico`；若 favicon 也加载失败，回退显示站点名首字符（与 emerald 的 `AvatarFallback` 一致）。
+
+## 架构与组件
+
+### 新增组件 `src/components/shell/SiteHeader.tsx`
+- 纯展示组件。读取：
+  - `usePublicConfig()` → `sitename`（回退 `"Komari"`，与后端默认一致）。
+  - `useThemeSettings()` → `showSiteHeader`（开关）、`siteHeaderLogo`（自定义 Logo URL）。
+- 结构：
+  - 左侧：Logo `<img>`（`src` = 自定义 URL 或 `/favicon.ico`；`onError` 回退首字母占位块）+ 站点名文本，整体包在 `<Link to="/">`，点击回首页。
+  - 右侧：为右上角悬浮球留出安全间距，暂不放按钮（避免与悬浮球功能重复）。
+- 交互：sticky 固定顶部；滚动监听切换毛玻璃背景（轻量 scroll 监听，阈值约 4–8px）。
+- 渲染条件：`showSiteHeader === true` 时才渲染；主题管理视图（`view=theme-manage`）不渲染（与 `FloatingControls` 的判断一致）。
+
+### 新增样式 `src/styles/site-header.css`
+- 复用现有 CSS 变量（`--surface`、`--text-primary`、`--text-secondary` 等），风格与卡片一致。
+- 通过 `@import` 并入 `src/styles/index.css`。
+- 关键类：sticky 容器、滚动态毛玻璃（`backdrop-blur` + 半透明背景 + 底部分隔线）、Logo 尺寸（约 32px，圆角方形）、首字母占位块。
+
+### 挂载点 `src/components/shell/AppShell.tsx`
+- 在 `<main>` 之前渲染 `<SiteHeader />`。
+- 悬浮球位置与现有逻辑保持不变；Header 右侧留白避开悬浮球，避免右上角重叠。
+
+## 主题设置（融入现有配置系统，改动最小）
+
+### `src/utils/themeSettings.ts`
+在三处各加两个字段（遵循现有 `enabledUnlessFalse` / `normalizePlainText` 归一化风格）：
+- `showSiteHeader: boolean`，默认 `true`（`enabledUnlessFalse`）。
+- `siteHeaderLogo: string`，默认 `""`（`normalizePlainText` 或 `normalizeBackgroundUrl` 复用其一做去空白/校验）。
+
+涉及：`ResolvedThemeSettings` 接口、`DEFAULT_THEME_SETTINGS`、`normalizeThemeSettings`。
+
+### `src/pages/ThemeManage.tsx`
+- `pickManagedThemeSettings` 增加 `showSiteHeader`、`siteHeaderLogo` 两项（草稿类型与内容签名自动派生）。
+- 新增一个「顶部标题栏」`InstancePanel` 区块，复用背景图那套 UI 模式：
+  - 「显示标题栏」开关 → `patch("showSiteHeader", ...)`。
+  - 「自定义 Logo URL」输入框 → `patch("siteHeaderLogo", ...)`，占位提示「留空则使用后台上传的站点图标」。
+
+## 错误处理
+
+- Logo（favicon 或自定义 URL）加载失败 → `onError` 切到站点名首字母占位块，不留破图。
+- `sitename` 为空 → 回退 `"Komari"`。
+- config 未就绪（`useThemeSettings().isReady === false`）→ Header 不闪烁：可先不渲染或渲染占位，待 ready 后稳定呈现。
+
+## 测试
+
+- 单元测试：为 `normalizeThemeSettings` 的两个新字段补测（默认值、非法值回退），跟随现有 `src/utils/__tests__/` 中 themeSettings 相关测试风格。
+- 手动验证清单：
+  - 开关：关闭后 Header 不出现；开启后出现。
+  - 自定义 URL：填写后 Logo 切换为该图；留空时用 `/favicon.ico`。
+  - 回退：favicon 不存在时显示首字母占位。
+  - 滚动：向下滚动出现毛玻璃背景。
+  - 移动端：窄屏不与悬浮球重叠。
+  - 点击：点 Logo/站点名从详情页回到首页。
+
+## 明确不做（YAGNI）
+
+- 不做浅色 / 深色分开的双 Logo（背景图那种 `A|B` 写法）——如后续需要再加。
+- 不在 Header 右侧重复放主题 / 后台按钮——悬浮球已提供。
+- 不新增站点描述副标题（保持标题栏简洁；如需可后续扩展）。

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router-dom";
 import { BackgroundLayer } from "./BackgroundLayer";
 import { FloatingControls } from "./FloatingControls";
+import { SiteHeader } from "./SiteHeader";
 import { useAppearance } from "@/hooks/useAppearance";
 import { useSiteMetadata } from "@/hooks/useSiteMetadata";
 import { useMetricColorsSync } from "@/hooks/useMetricColors";
@@ -13,6 +14,7 @@ export function AppShell() {
   return (
     <div className="relative flex min-h-screen flex-col">
       <BackgroundLayer />
+      <SiteHeader />
       <FloatingControls />
       {/* max-[720px]:pt-16 给右上角固定的浮动控件留出空间，避免窄屏下展开的控件行盖住首张卡片的头部 */}
       <main className="flex-1 px-3 pb-8 pt-5 max-[720px]:pt-16 sm:px-5 md:px-6 lg:px-8 lg:pt-6">

--- a/src/components/shell/SiteHeader.tsx
+++ b/src/components/shell/SiteHeader.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { clsx } from "clsx";
+import { usePublicConfig } from "@/hooks/usePublicConfig";
+import { useThemeSettings } from "@/hooks/useThemeSettings";
+
+const FALLBACK_SITENAME = "Komari";
+// 后台上传的站点图标由后端存为 ./data/favicon.ico,统一通过该端点提供(见 Komari
+// web/public/public.go 的 favicon 优先策略)。自定义 Logo 留空时回退到它。
+const FAVICON_URL = "/favicon.ico";
+
+// 顶部品牌标题栏:sticky 固定,向下滚动后叠加毛玻璃背景与分隔线。左侧展示站点 Logo
+// (自定义 URL 或后台上传的 favicon)+ 站点名,整体可点击回首页。可在主题管理页开关。
+export function SiteHeader() {
+  const [searchParams] = useSearchParams();
+  // 与 FloatingControls 一致:主题管理视图下不渲染标题栏。
+  if (searchParams.get("view") === "theme-manage") {
+    return null;
+  }
+  return <SiteHeaderInner />;
+}
+
+function SiteHeaderInner() {
+  const { data: config } = usePublicConfig();
+  const { showSiteHeader, siteHeaderLogo, isReady } = useThemeSettings();
+  const [scrolled, setScrolled] = useState(false);
+  // Logo 加载失败(favicon 未上传 / 自定义 URL 失效)时切到站点名首字母占位。
+  const [logoFailed, setLogoFailed] = useState(false);
+  // 记录上次尝试的 logo 源:源变化时重置失败态,让新地址有机会重新加载。
+  const lastLogoSrc = useRef<string | null>(null);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 4);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // config 未就绪前不渲染,避免站点名/Logo 从占位跳成真实值的闪烁。
+  if (!isReady || !showSiteHeader) {
+    return null;
+  }
+
+  const sitename = config?.sitename?.trim() || FALLBACK_SITENAME;
+  // 自定义 Logo 支持 `浅色|深色` 写法(复用背景图归一化),这里只取第一段作为通用 Logo。
+  const customLogo = siteHeaderLogo.split("|")[0]?.trim() || "";
+  const logoSrc = customLogo || FAVICON_URL;
+  if (lastLogoSrc.current !== logoSrc) {
+    lastLogoSrc.current = logoSrc;
+    if (logoFailed) setLogoFailed(false);
+  }
+
+  return (
+    <header className={clsx("site-header", scrolled && "is-scrolled")}>
+      <div className="site-header-inner">
+        <Link to="/" className="site-header-brand" aria-label={`返回 ${sitename} 首页`}>
+          <span className="site-header-logo" aria-hidden={logoFailed ? undefined : true}>
+            {logoFailed ? (
+              <span className="site-header-logo-fallback">{sitename.slice(0, 1)}</span>
+            ) : (
+              <img
+                src={logoSrc}
+                alt={sitename}
+                onError={() => setLogoFailed(true)}
+                loading="eager"
+                decoding="async"
+              />
+            )}
+          </span>
+          <span className="site-header-name">{sitename}</span>
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/src/pages/ThemeManage.tsx
+++ b/src/pages/ThemeManage.tsx
@@ -13,6 +13,7 @@ import {
   List,
   ListFilter,
   Moon,
+  PanelTop,
   RefreshCw,
   Rows3,
   Save,
@@ -257,6 +258,8 @@ function pickManagedThemeSettings(settings: ResolvedThemeSettings) {
     backgroundImageMobile: settings.backgroundImageMobile,
     backgroundAlignment: settings.backgroundAlignment,
     surfaceOpacity: settings.surfaceOpacity,
+    showSiteHeader: settings.showSiteHeader,
+    siteHeaderLogo: settings.siteHeaderLogo,
   };
 }
 
@@ -536,6 +539,7 @@ export function ThemeManage() {
       backgroundImage: normalizeBackgroundUrl(rest.backgroundImage),
       backgroundImageMobile: normalizeBackgroundUrl(rest.backgroundImageMobile),
       backgroundAlignment: normalizeBackgroundAlignment(rest.backgroundAlignment),
+      siteHeaderLogo: normalizeBackgroundUrl(rest.siteHeaderLogo),
     };
   }, [draft]);
 
@@ -926,6 +930,45 @@ export function ThemeManage() {
                 : " 需先在上方设置背景图后才会生效。"}
             </span>
           </div>
+        </div>
+      </InstancePanel>
+
+      <InstancePanel
+        title="顶部标题栏"
+        description="在页面顶部展示站点 Logo 与名称，向下滚动时背景自动毛玻璃虚化。Logo 默认使用后台上传的站点图标；站点名称取自后台「站点名称」设置。"
+        aside={<PanelTop size={16} />}
+      >
+        <div className="flex flex-col gap-4">
+          <label className="surface-inset flex items-center justify-between gap-3 px-4 py-3">
+            <span className="min-w-0">
+              <span className="block text-[13px] font-medium text-[var(--text-primary)]">
+                显示标题栏
+              </span>
+              <span className="mt-1 block text-[11px] text-[var(--text-tertiary)]">
+                关闭后页面顶部不显示标题栏，站点回到无品牌栏的布局；再次开启即恢复。
+              </span>
+            </span>
+            <input
+              type="checkbox"
+              checked={draft.showSiteHeader}
+              onChange={(event) => patch("showSiteHeader", event.target.checked)}
+              className="h-4 w-4 shrink-0 accent-[var(--accent-500)]"
+            />
+          </label>
+          <label className="flex min-w-0 flex-col gap-2">
+            <span className="text-[12px] font-medium text-[var(--text-secondary)]">
+              自定义 Logo URL
+            </span>
+            <input
+              value={draft.siteHeaderLogo}
+              onChange={(event) => patch("siteHeaderLogo", event.target.value)}
+              placeholder="留空则使用后台上传的站点图标"
+              className="surface-inset w-full px-3 py-2 text-[13px] outline-none"
+            />
+            <span className="text-[11px] text-[var(--text-tertiary)]">
+              填写图片地址可覆盖默认站点图标。图片加载失败时会回退显示站点名称首字。
+            </span>
+          </label>
         </div>
       </InstancePanel>
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,6 +8,7 @@
 @import "./mini-node-card.css";
 @import "./node-list.css";
 @import "./os-logo.css";
+@import "./site-header.css";
 
 @theme {
   --font-sans:

--- a/src/styles/site-header.css
+++ b/src/styles/site-header.css
@@ -1,0 +1,106 @@
+/* 顶部品牌标题栏。sticky 固定在视口顶部,默认透明融入背景;向下滚动后(is-scrolled)
+   叠加半透明表面 + 毛玻璃 + 底部分隔线,与悬浮球/卡片的磨砂语言一致。 */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  border-bottom: 1px solid transparent;
+  background: transparent;
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    backdrop-filter 200ms ease;
+}
+
+.site-header.is-scrolled {
+  background: color-mix(in srgb, var(--surface-a) 78%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--border) 90%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.site-header-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 1720px;
+  margin: 0 auto;
+  min-height: 56px;
+  padding: 8px 12px;
+  /* 右上角悬浮球固定在 top/right ≈1rem,收起态约 40px 宽。给右侧留出安全间距,
+     避免品牌区在窄屏与悬浮球重叠(悬浮球 z-index 40 > 本栏 30,重叠时会压住)。 */
+  padding-right: max(56px, env(safe-area-inset-right));
+}
+
+@media (min-width: 640px) {
+  .site-header-inner {
+    padding-left: 20px;
+    padding-right: max(64px, env(safe-area-inset-right));
+  }
+}
+
+@media (min-width: 1024px) {
+  .site-header-inner {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+
+.site-header-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  border-radius: 10px;
+  padding: 4px 8px 4px 4px;
+  margin-left: -4px;
+  color: var(--text-primary);
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+}
+
+.site-header-brand:hover {
+  background: color-mix(in srgb, var(--hover-bg-a) 60%, transparent);
+}
+
+.site-header-brand:active {
+  transform: scale(0.99);
+}
+
+.site-header-logo {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface-elev-a);
+  border: 1px solid var(--border-subtle);
+}
+
+.site-header-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.site-header-logo-fallback {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.site-header-name {
+  min-width: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/utils/__tests__/themeSettings.test.ts
+++ b/src/utils/__tests__/themeSettings.test.ts
@@ -34,4 +34,20 @@ describe("normalizeThemeSettings", () => {
       normalizeThemeSettings({ hiddenNodes: "节点A, 节点A\nuuid-1；节点B" } as never).hiddenNodes,
     ).toEqual(["节点A", "uuid-1", "节点B"]);
   });
+
+  it("defaults site header on unless explicitly disabled", () => {
+    expect(normalizeThemeSettings({}).showSiteHeader).toBe(true);
+    expect(normalizeThemeSettings({ showSiteHeader: false }).showSiteHeader).toBe(false);
+    // 非布尔假值不算关闭(只有严格 false 才关)。
+    expect(normalizeThemeSettings({ showSiteHeader: "no" } as never).showSiteHeader).toBe(true);
+  });
+
+  it("normalizes the site header logo url: defaults empty, trims, ignores non-strings", () => {
+    expect(normalizeThemeSettings({}).siteHeaderLogo).toBe("");
+    expect(
+      normalizeThemeSettings({ siteHeaderLogo: "  https://a.com/logo.png  " } as never)
+        .siteHeaderLogo,
+    ).toBe("https://a.com/logo.png");
+    expect(normalizeThemeSettings({ siteHeaderLogo: 123 } as never).siteHeaderLogo).toBe("");
+  });
 });

--- a/src/utils/themeSettings.ts
+++ b/src/utils/themeSettings.ts
@@ -69,6 +69,8 @@ export interface ResolvedThemeSettings {
   backgroundImageMobile: string;
   backgroundAlignment: string;
   surfaceOpacity: number;
+  showSiteHeader: boolean;
+  siteHeaderLogo: string;
 }
 
 export const DEFAULT_THEME_SETTINGS: ResolvedThemeSettings = {
@@ -110,6 +112,9 @@ export const DEFAULT_THEME_SETTINGS: ResolvedThemeSettings = {
   backgroundImageMobile: "",
   backgroundAlignment: DEFAULT_BACKGROUND_ALIGNMENT,
   surfaceOpacity: DEFAULT_SURFACE_OPACITY,
+  // 默认开:站长上传的站点图标(favicon)本就期望被展示;需要时可在管理页关闭。
+  showSiteHeader: true,
+  siteHeaderLogo: "",
 };
 
 export function isAppearance(value: unknown): value is Appearance {
@@ -218,5 +223,9 @@ export function normalizeThemeSettings(
     backgroundImageMobile: normalizeBackgroundUrl(settings?.backgroundImageMobile),
     backgroundAlignment: normalizeBackgroundAlignment(settings?.backgroundAlignment),
     surfaceOpacity: normalizeSurfaceOpacity(settings?.surfaceOpacity),
+    // 顶部标题栏默认开;自定义 Logo 复用背景图的 URL 归一化(含防注入 sanitize)。
+    // 留空时 SiteHeader 回退到站点 favicon(/favicon.ico)。
+    showSiteHeader: enabledUnlessFalse(settings?.showSiteHeader),
+    siteHeaderLogo: normalizeBackgroundUrl(settings?.siteHeaderLogo),
   };
 }


### PR DESCRIPTION
在页面顶部新增 sticky 标题栏，展示站点 Logo（默认取后台上传的
favicon /favicon.ico）与名称（sitename），向下滚动时背景毛玻璃虚化，
点击可回到首页。可在主题管理页开关，并支持自定义 Logo URL。

- 新增 SiteHeader 组件与 site-header.css，挂载于 AppShell
- themeSettings 增加 showSiteHeader（默认开）、siteHeaderLogo 两项配置
- ThemeManage 新增「顶部标题栏」配置区块
- 补充 normalizeThemeSettings 新字段的单元测试
- Logo 加载失败回退站点名首字母；主题管理视图下不显示标题栏