### PR TITLE
feat: Ping 图表补齐哪吒风格的丢包与缩放标注

### DIFF
--- a/src/components/instance/ChartRangeSlider.tsx
+++ b/src/components/instance/ChartRangeSlider.tsx
@@ -1,0 +1,257 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import {
+  clampZoomWindow,
+  isFullZoomWindow,
+  panZoomWindow,
+  type ChartZoomWindow,
+} from "./chartZoom";
+
+export interface ChartRangePreviewSeries {
+  values: ReadonlyArray<number | null | undefined>;
+  color: string;
+}
+
+// 键盘微调步长：与 chartZoom 的最小窗口同量级，按一下就有肉眼可见的位移。
+const KEYBOARD_STEP = 0.02;
+const PREVIEW_LINE_ALPHA = 0.55;
+
+type DragState =
+  | { kind: "start" }
+  | { kind: "end" }
+  | { kind: "pan"; grabOffset: number };
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function toPercent(ratio: number) {
+  return `${(clamp(ratio, 0, 1) * 100).toFixed(4)}%`;
+}
+
+function drawPreview(
+  canvas: HTMLCanvasElement,
+  series: readonly ChartRangePreviewSeries[],
+) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const ratio = window.devicePixelRatio || 1;
+  const width = canvas.clientWidth;
+  const height = canvas.clientHeight;
+  if (width <= 0 || height <= 0) return;
+
+  canvas.width = Math.round(width * ratio);
+  canvas.height = Math.round(height * ratio);
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let length = 0;
+  for (const item of series) {
+    length = Math.max(length, item.values.length);
+    for (const value of item.values) {
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+  }
+  if (length < 2 || min === Number.POSITIVE_INFINITY) return;
+
+  const span = max - min || 1;
+  const padding = 2;
+  const usableHeight = Math.max(1, height - padding * 2);
+  ctx.lineWidth = 1;
+  ctx.globalAlpha = PREVIEW_LINE_ALPHA;
+
+  for (const item of series) {
+    ctx.strokeStyle = item.color;
+    ctx.beginPath();
+    let pendingMove = true;
+    for (let index = 0; index < item.values.length; index += 1) {
+      const value = item.values[index];
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        // null(丢包/中断) 断开缩略线；undefined(off-phase) 同样跳过，缩略图不需要区分两者。
+        pendingMove = true;
+        continue;
+      }
+      const x = (index / (length - 1)) * width;
+      const y = padding + usableHeight * (1 - (value - min) / span);
+      if (pendingMove) {
+        ctx.moveTo(x, y);
+        pendingMove = false;
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+    ctx.stroke();
+  }
+}
+
+/**
+ * 主图下方的横向缩放条，对标哪吒面板服务监控图的 dataZoom：
+ * 背景是整段数据的缩略曲线，左右把手改区间、中间色块拖动平移、双击恢复全量。
+ * 窗口比例是唯一数据源，主图的 x scale 由它单向驱动。
+ */
+export function ChartRangeSlider({
+  window: zoomWindow,
+  series,
+  onChange,
+  onReset,
+}: {
+  window: ChartZoomWindow;
+  series: readonly ChartRangePreviewSeries[];
+  onChange: (next: ChartZoomWindow) => void;
+  onReset: () => void;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dragRef = useRef<DragState | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const render = () => drawPreview(canvas, series);
+    render();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(render);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, [series]);
+
+  const ratioFromClientX = useCallback((clientX: number) => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) return null;
+    return clamp((clientX - rect.left) / rect.width, 0, 1);
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const role = (event.target as HTMLElement).dataset.dragRole;
+      if (!role) return;
+      const ratio = ratioFromClientX(event.clientX);
+      if (ratio == null) return;
+      event.preventDefault();
+      rootRef.current?.setPointerCapture(event.pointerId);
+      dragRef.current =
+        role === "pan"
+          ? { kind: "pan", grabOffset: ratio - zoomWindow.start }
+          : role === "start"
+            ? { kind: "start" }
+            : { kind: "end" };
+    },
+    [ratioFromClientX, zoomWindow.start],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const ratio = ratioFromClientX(event.clientX);
+      if (ratio == null) return;
+      if (drag.kind === "pan") {
+        onChange(panZoomWindow(zoomWindow, ratio - drag.grabOffset - zoomWindow.start));
+        return;
+      }
+      onChange(
+        clampZoomWindow(
+          drag.kind === "start"
+            ? { start: ratio, end: zoomWindow.end }
+            : { start: zoomWindow.start, end: ratio },
+        ),
+      );
+    },
+    [onChange, ratioFromClientX, zoomWindow],
+  );
+
+  const endDrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    if (rootRef.current?.hasPointerCapture(event.pointerId)) {
+      rootRef.current.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const nudge = useCallback(
+    (edge: "start" | "end", delta: number) => {
+      onChange(
+        clampZoomWindow(
+          edge === "start"
+            ? { start: zoomWindow.start + delta, end: zoomWindow.end }
+            : { start: zoomWindow.start, end: zoomWindow.end + delta },
+        ),
+      );
+    },
+    [onChange, zoomWindow],
+  );
+
+  const handleKeyDown = (edge: "start" | "end") => (event: ReactKeyboardEvent) => {
+    if (event.key === "ArrowLeft") nudge(edge, -KEYBOARD_STEP);
+    else if (event.key === "ArrowRight") nudge(edge, KEYBOARD_STEP);
+    else if (event.key === "Home") nudge(edge, -1);
+    else if (event.key === "End") nudge(edge, 1);
+    else return;
+    event.preventDefault();
+  };
+
+  const windowWidth = Math.max(0, zoomWindow.end - zoomWindow.start);
+
+  return (
+    <div className="instance-range-slider">
+      <div
+        ref={rootRef}
+        className="instance-range-slider-track"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onDoubleClick={onReset}
+      >
+        <canvas ref={canvasRef} className="instance-range-slider-canvas" aria-hidden />
+        <div
+          className="instance-range-slider-window"
+          data-drag-role="pan"
+          style={{ left: toPercent(zoomWindow.start), width: toPercent(windowWidth) }}
+        >
+          <button
+            type="button"
+            className="instance-range-slider-handle is-start"
+            data-drag-role="start"
+            role="slider"
+            aria-label="缩放起点"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(zoomWindow.start * 100)}
+            aria-valuetext={`起点 ${Math.round(zoomWindow.start * 100)}%`}
+            onKeyDown={handleKeyDown("start")}
+          />
+          <button
+            type="button"
+            className="instance-range-slider-handle is-end"
+            data-drag-role="end"
+            role="slider"
+            aria-label="缩放终点"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(zoomWindow.end * 100)}
+            aria-valuetext={`终点 ${Math.round(zoomWindow.end * 100)}%`}
+            onKeyDown={handleKeyDown("end")}
+          />
+        </div>
+      </div>
+      <button
+        type="button"
+        className="instance-toggle-button instance-range-slider-reset"
+        onClick={onReset}
+        disabled={isFullZoomWindow(zoomWindow)}
+      >
+        恢复全部
+      </button>
+    </div>
+  );
+}

--- a/src/components/instance/PingChart.tsx
+++ b/src/components/instance/PingChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import UplotReact from "uplot-react";
 import type uPlot from "uplot";
 import { Eye, EyeOff, RefreshCw } from "lucide-react";
@@ -14,6 +14,8 @@ import {
   type ChartTooltipState,
 } from "./chartShared";
 import { ChartTooltip, SwitchToggle } from "./ChartParts";
+import { ChartRangeSlider, type ChartRangePreviewSeries } from "./ChartRangeSlider";
+import { PingTaskStatsPopover } from "./PingTaskStatsPopover";
 import {
   cutPeakValues,
   detectTypicalIntervalSeconds,
@@ -21,6 +23,19 @@ import {
   insertMetricGapSentinels,
   smoothByCount,
 } from "./chartData";
+import {
+  buildPingSeriesOverlay,
+  drawPingOverlay,
+  type PingSeriesOverlay,
+} from "./pingChartOverlay";
+import {
+  clampZoomWindow,
+  FULL_ZOOM_WINDOW,
+  rangeToZoomWindow,
+  zoomWindowIndexRange,
+  zoomWindowToRange,
+  type ChartZoomWindow,
+} from "./chartZoom";
 import { latencyHeatColor, lossHeatColor } from "@/utils/metricTone";
 import { historyChartRangeSeconds, historyCoverageLabel } from "@/utils/historyRange";
 import { resolvePingChartInterval, resolvePingSampleCounts } from "@/utils/pingMetrics";
@@ -123,7 +138,20 @@ export function PingChart({
   const [hiddenTasks, setHiddenTasks] = useState<Set<number>>(new Set());
   const [connectNulls, setConnectNulls] = useState(false);
   const [cutPeak, setCutPeak] = useState(false);
+  const [showLossLines, setShowLossLines] = useState(true);
+  const [showExtremePins, setShowExtremePins] = useState(true);
+  const [zoomWindow, setZoomWindow] = useState<ChartZoomWindow>(FULL_ZOOM_WINDOW);
   const chartRef = useRef<uPlot.AlignedData>([[]]);
+  // 缩放、覆盖层和丢包率都通过 ref 喂给 uPlot，让 options 对象保持稳定引用——
+  // 否则每拖一下滑块 uplot-react 就会销毁重建图表，入场动画会反复重放。
+  const plotRef = useRef<uPlot | null>(null);
+  const xRangeRef = useRef<[number, number]>([0, 1]);
+  const fullXRangeRef = useRef<[number, number] | null>(null);
+  const yRangeRef = useRef<[number, number]>([0, 100]);
+  const overlaysRef = useRef<PingSeriesOverlay[]>([]);
+  const lossByTaskRef = useRef<Map<number, number>>(new Map());
+  const overlayFlagsRef = useRef({ showLossLines, showExtremePins });
+  const applyZoomRef = useRef<(next: ChartZoomWindow) => void>(() => {});
   const [tooltip, setTooltip] = useState<ChartTooltipState>({
     show: false,
     left: 0,
@@ -274,15 +302,59 @@ export function PingChart({
     return historyCoverageLabel(coverageMeta, times[0], times[times.length - 1]);
   }, [chart, coverageMeta]);
 
-  const yRange = useMemo<[number | null, number | null]>(() => {
-    if (!chart) return [null, null];
+  // 时间轴的完整跨度：优先用后端声明的请求区间，缺失时退回实际数据首尾。
+  // 缩放窗口是它的比例切片，主图 x scale 只由这里派生。
+  const fullXRange = useMemo<[number, number] | null>(() => {
+    if (requestedXRange) return requestedXRange;
+    const times = chart?.[0];
+    if (!times?.length) return null;
+    const start = times[0];
+    const end = times[times.length - 1];
+    return end > start ? [start, end] : null;
+  }, [chart, requestedXRange]);
+
+  const zoomedXRange = useMemo<[number, number] | null>(
+    () => (fullXRange ? zoomWindowToRange(fullXRange, zoomWindow) : null),
+    [fullXRange, zoomWindow],
+  );
+
+  // 可见区间内一个点都没有时退回 null，让下游按「整段」处理而不是按空区间处理。
+  const visibleIndexRange = useMemo(() => {
+    const times = chart?.[0];
+    if (!times?.length || !zoomedXRange) return null;
+    const range = zoomWindowIndexRange(times as ReadonlyArray<number>, zoomedXRange);
+    return range.toIndex >= 0 ? range : null;
+  }, [chart, zoomedXRange]);
+
+  const overlays = useMemo<PingSeriesOverlay[]>(() => {
+    if (!chart) return [];
+    return tasks
+      .filter((task) => visibleTaskIds.has(task.id))
+      .map((task) => {
+        const seriesIndex = (taskIndexById.get(task.id) ?? 0) + 1;
+        const values = (chart[seriesIndex] ?? []) as ReadonlyArray<number | null | undefined>;
+        return buildPingSeriesOverlay(
+          values,
+          taskColors.get(task.id) ?? colorForSeries(seriesIndex - 1, tasks.length),
+          visibleIndexRange ?? undefined,
+        );
+      });
+  }, [chart, taskColors, taskIndexById, tasks, visibleIndexRange, visibleTaskIds]);
+
+  // y 轴跟随可见区间重算：放大到某一小段后，纵向也应该铺满这段的量级，
+  // 否则缩放只是横向拉伸，看不清细节。
+  const yRange = useMemo<[number, number]>(() => {
+    if (!chart) return [0, 100];
+    const fromIndex = visibleIndexRange?.fromIndex ?? 0;
+    const toIndex = visibleIndexRange?.toIndex ?? (chart[0]?.length ?? 1) - 1;
     let min = Number.POSITIVE_INFINITY;
     let max = Number.NEGATIVE_INFINITY;
     for (let index = 0; index < tasks.length; index += 1) {
       if (!visibleTaskIds.has(tasks[index].id)) continue;
       const series = chart[index + 1] as Array<number | null | undefined> | undefined;
       if (!series) continue;
-      for (const value of series) {
+      for (let cursor = fromIndex; cursor <= toIndex; cursor += 1) {
+        const value = series[cursor];
         if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
           if (value < min) min = value;
           if (value > max) max = value;
@@ -296,7 +368,40 @@ export function PingChart({
     }
     const pad = Math.max(5, (max - min) * 0.12);
     return [Math.max(0, min - pad), max + pad];
-  }, [chart, tasks, visibleTaskIds]);
+  }, [chart, tasks, visibleIndexRange, visibleTaskIds]);
+
+  // 这些 ref 必须在 render 期间对齐：uPlot 挂载那一帧就会调用 scales 的 range() 和 draw hook，
+  // 放到 effect 里赋值会晚一帧，首帧会用上一轮(甚至初始占位)的区间和覆盖层画一次。
+  overlaysRef.current = overlays;
+  overlayFlagsRef.current = { showLossLines, showExtremePins };
+  fullXRangeRef.current = fullXRange;
+  if (zoomedXRange) xRangeRef.current = zoomedXRange;
+  yRangeRef.current = yRange;
+
+  useEffect(() => {
+    plotRef.current?.redraw();
+  }, [overlays, showExtremePins, showLossLines]);
+
+  useEffect(() => {
+    const plot = plotRef.current;
+    if (!plot) return;
+    // scales 的 range 函数会读上面的 ref 覆盖这里传入的值；传当前值只是为了触发一次重算。
+    if (zoomedXRange) plot.setScale("x", { min: zoomedXRange[0], max: zoomedXRange[1] });
+    plot.setScale("y", { min: yRange[0], max: yRange[1] });
+  }, [yRange, zoomedXRange]);
+
+  // 换节点或换时间范围后旧的缩放窗口不再有意义，回到全量。
+  useEffect(() => {
+    setZoomWindow(FULL_ZOOM_WINDOW);
+  }, [hours, uuid]);
+
+  const applyZoomWindow = useCallback((next: ChartZoomWindow) => {
+    setZoomWindow(clampZoomWindow(next));
+  }, []);
+
+  const resetZoomWindow = useCallback(() => setZoomWindow(FULL_ZOOM_WINDOW), []);
+
+  applyZoomRef.current = applyZoomWindow;
 
   const baseOptions = useMemo<Omit<uPlot.Options, "width" | "height"> | null>(() => {
     if (!chart) return null;
@@ -312,6 +417,7 @@ export function PingChart({
             const taskIndex = taskIndexById.get(task.id) ?? 0;
             const raw = chartRef.current[taskIndex + 1]?.[idx] as number | null | undefined;
             return {
+              taskId: task.id,
               label: taskLabels.get(task.id) ?? `任务 #${task.id}`,
               raw: typeof raw === "number" && Number.isFinite(raw) ? raw : null,
               color: taskColors.get(task.id) ?? colorForSeries(taskIndex, tasks.length),
@@ -322,21 +428,27 @@ export function PingChart({
             if (b.raw == null) return -1;
             return b.raw - a.raw;
           })
-          .map(({ label, raw, color }) => ({
-            label,
-            value: raw == null ? "—" : `${raw.toFixed(1)} ms`,
-            color,
-          })),
+          .map(({ label, raw, color, taskId }) => {
+            // 对标哪吒服务监控图的图例格式「名称 丢包%: 延迟 ms」，
+            // 悬停时不用回头去看图例就知道这条线当前的健康度。
+            const loss = lossByTaskRef.current.get(taskId);
+            return {
+              label: loss == null ? label : `${label} ${loss.toFixed(1)}%`,
+              value: raw == null ? "—" : `${raw.toFixed(1)} ms`,
+              color,
+            };
+          }),
     });
     return {
       padding: [10, 14, 12, 2],
-      cursor: { drag: { x: true, y: false } },
+      // setScale: false —— 拖拽出的选区交给 setSelect hook 换算成缩放窗口，
+      // 由窗口统一驱动 x scale，避免 uPlot 自缩放与滑块两套状态打架。
+      // dist 要求先拖够 8px 才算选区，否则想点一下图表却抖了两像素就会意外缩放。
+      cursor: { drag: { x: true, y: false, setScale: false, dist: 8 } },
       legend: { show: false },
       scales: {
-        x: requestedXRange
-          ? { time: true, auto: false, range: () => requestedXRange }
-          : { time: true },
-        y: { auto: false, range: yRange },
+        x: { time: true, auto: false, range: () => xRangeRef.current },
+        y: { auto: false, range: () => yRangeRef.current },
       },
       axes: [
         {
@@ -375,9 +487,25 @@ export function PingChart({
         ],
         destroy: [tooltipHooks.onDestroy],
         setCursor: [tooltipHooks.onSetCursor],
+        draw: [
+          (u) => {
+            drawPingOverlay(u, overlaysRef.current, overlayFlagsRef.current);
+          },
+        ],
+        setSelect: [
+          (u) => {
+            if (u.select.width <= 0) return;
+            const full = fullXRangeRef.current;
+            const from = u.posToVal(u.select.left, "x");
+            const to = u.posToVal(u.select.left + u.select.width, "x");
+            u.setSelect({ left: 0, top: 0, width: 0, height: 0 }, false);
+            if (!full) return;
+            applyZoomRef.current(rangeToZoomWindow(full, [from, to]));
+          },
+        ],
       },
     };
-  }, [chart, connectNulls, hiddenTasks, hours, isDark, requestedXRange, taskColors, taskIndexById, taskLabels, tasks, visibleTasks, yRange]);
+  }, [chart, connectNulls, hiddenTasks, hours, isDark, taskColors, taskIndexById, taskLabels, tasks, visibleTasks]);
 
   const options = useMemo<uPlot.Options | null>(
     () => (baseOptions ? { ...baseOptions, width: w, height: h } : null),
@@ -439,6 +567,26 @@ export function PingChart({
       };
     });
   }, [pingStats, sortedRecords, taskColors, tasks, uuid]);
+
+  const lossByTask = useMemo(
+    () => new Map(taskStats.map((task) => [task.id, task.loss])),
+    [taskStats],
+  );
+  // 同上：tooltip 的行是在 uPlot 的 hook 里现算的，走 ref 才能读到最新丢包率
+  // 而不必让整个 options 依赖 taskStats。
+  lossByTaskRef.current = lossByTask;
+
+  // 缩放条的缩略曲线直接复用主图已降采样的数据，两者不会出现形状对不上的情况。
+  const previewSeries = useMemo<ChartRangePreviewSeries[]>(() => {
+    if (!chart) return [];
+    return visibleTasks.map((task) => {
+      const seriesIndex = (taskIndexById.get(task.id) ?? 0) + 1;
+      return {
+        values: (chart[seriesIndex] ?? []) as ReadonlyArray<number | null | undefined>,
+        color: taskColors.get(task.id) ?? colorForSeries(seriesIndex - 1, tasks.length),
+      };
+    });
+  }, [chart, taskColors, taskIndexById, tasks.length, visibleTasks]);
 
   const refetchAll = () => {
     void refetchRecords();
@@ -503,6 +651,18 @@ export function PingChart({
           onToggle={() => setConnectNulls((value) => !value)}
           title="关闭：如实显示中断/丢包断点；开启：跨过所有空缺连成完整曲线（更好看，但看不出掉线）。注：偶尔漏一两次采样的小空缺始终自动桥接，不受此开关影响。"
         />
+        <SwitchToggle
+          label="丢包竖线"
+          active={showLossLines}
+          onToggle={() => setShowLossLines((value) => !value)}
+          title="在每次探测失败的时刻立一条同色竖线，一眼看出丢包集中在哪些时段"
+        />
+        <SwitchToggle
+          label="极值标记"
+          active={showExtremePins}
+          onToggle={() => setShowExtremePins((value) => !value)}
+          title="在每条线当前可见区间的最高/最低点标出数值气泡"
+        />
         <button type="button" className="instance-toggle-button" onClick={toggleAll}>
           {hiddenTasks.size === 0 ? <EyeOff size={14} aria-hidden /> : <Eye size={14} aria-hidden />}
           {hiddenTasks.size === 0 ? "隐藏全部" : "显示全部"}
@@ -522,42 +682,59 @@ export function PingChart({
       <div className="instance-ping-tasks">
         {taskStats.map((task) => {
           const visible = !hiddenTasks.has(task.id);
+          const label = taskLabels.get(task.id) ?? `任务 #${task.id}`;
           return (
-            <button
+            <div
               key={task.id}
-              type="button"
               className="instance-ping-task"
               data-visible={visible ? "true" : "false"}
-              aria-pressed={visible}
-              onClick={() => toggleTask(task.id)}
               style={{ borderColor: visible ? task.color : "var(--border-subtle)" }}
-              title={[
-                taskLabels.get(task.id) ?? `任务 #${task.id}`,
-                `当前 ${task.latest != null ? `${task.latest.toFixed(1)} ms` : "—"} | 均值 ${task.avg != null ? `${task.avg.toFixed(1)} ms` : "—"} | 丢包 ${task.loss.toFixed(1)}%`,
-                `p99 ${task.p99 != null ? `${task.p99.toFixed(0)} ms` : "—"} | 抖动 ${task.volatility != null ? task.volatility.toFixed(2) : "—"}`,
-                `min ${task.min != null ? `${task.min.toFixed(0)} ms` : "—"} | max ${task.max != null ? `${task.max.toFixed(0)} ms` : "—"} | 样本 ${task.total ?? 0} | 间隔 ${task.interval}s`,
-              ].join("\n")}
             >
-              <span className="instance-ping-task-dot" style={{ background: task.color }} aria-hidden />
-              <span className="instance-ping-task-name">{taskLabels.get(task.id) ?? `任务 #${task.id}`}</span>
-              <span
-                className="instance-ping-task-primary"
-                style={{
-                  color:
-                    task.latest != null
-                      ? latencyHeatColor(task.latest)
-                      : "var(--text-tertiary)",
+              <button
+                type="button"
+                className="instance-ping-task-main"
+                aria-pressed={visible}
+                onClick={() => toggleTask(task.id)}
+              >
+                <span className="instance-ping-task-dot" style={{ background: task.color }} aria-hidden />
+                <span className="instance-ping-task-name">{label}</span>
+                <span
+                  className="instance-ping-task-primary"
+                  style={{
+                    color:
+                      task.latest != null
+                        ? latencyHeatColor(task.latest)
+                        : "var(--text-tertiary)",
+                  }}
+                >
+                  {task.latest != null ? `${task.latest.toFixed(1)} ms` : "—"}
+                </span>
+                <span
+                  className="instance-ping-task-loss"
+                  style={{ color: lossHeatColor(task.loss) }}
+                >
+                  {task.loss.toFixed(1)}%
+                </span>
+              </button>
+              <PingTaskStatsPopover
+                stat={{
+                  name: label,
+                  type: task.type,
+                  target: task.target,
+                  interval: task.interval,
+                  latest: task.latest,
+                  avg: task.avg,
+                  min: task.min,
+                  max: task.max,
+                  p50: task.p50,
+                  p99: task.p99,
+                  volatility: task.volatility,
+                  total: task.total,
+                  lost: task.lost,
+                  loss: task.loss,
                 }}
-              >
-                {task.latest != null ? `${task.latest.toFixed(1)} ms` : "—"}
-              </span>
-              <span
-                className="instance-ping-task-loss"
-                style={{ color: lossHeatColor(task.loss) }}
-              >
-                {task.loss.toFixed(1)}%
-              </span>
-            </button>
+              />
+            </div>
           );
         })}
       </div>
@@ -569,6 +746,12 @@ export function PingChart({
               key={`${uuid}-${hours}-${cutPeak ? "smooth" : "raw"}-${connectNulls ? "span" : "gap"}`}
               options={options}
               data={chart}
+              onCreate={(plot) => {
+                plotRef.current = plot;
+              }}
+              onDelete={() => {
+                plotRef.current = null;
+              }}
             />
             <ChartTooltip tooltip={tooltip} />
           </>
@@ -576,6 +759,15 @@ export function PingChart({
           <div className="instance-empty">当前已隐藏全部线路，点击上方按钮可恢复显示</div>
         )}
       </div>
+
+      {chart && options && visibleTasks.length > 0 && fullXRange && (
+        <ChartRangeSlider
+          window={zoomWindow}
+          series={previewSeries}
+          onChange={applyZoomWindow}
+          onReset={resetZoomWindow}
+        />
+      )}
     </InstancePanel>
   );
 }

--- a/src/components/instance/PingTaskStatsPopover.tsx
+++ b/src/components/instance/PingTaskStatsPopover.tsx
@@ -1,0 +1,109 @@
+import { createPortal } from "react-dom";
+import { Info } from "lucide-react";
+import { useAnchoredPopover } from "@/hooks/useAnchoredPopover";
+import { useFineHover } from "@/hooks/useMediaQuery";
+import { lossHeatColor } from "@/utils/metricTone";
+
+const POPOVER_WIDTH = 208;
+
+export interface PingTaskStatSummary {
+  name: string;
+  type: string;
+  target: string;
+  interval: number;
+  latest: number | null;
+  avg: number | null;
+  min: number | null;
+  max: number | null;
+  p50: number | null;
+  p99: number | null;
+  volatility: number | null;
+  total: number;
+  lost: number;
+  loss: number;
+}
+
+function formatMs(value: number | null) {
+  return value == null ? "—" : `${value.toFixed(1)} ms`;
+}
+
+/**
+ * 图例上的线路统计浮层。这些数字原先塞在原生 title 里，要停住鼠标等一秒才弹、
+ * 触屏上完全看不到；改成受控浮层后悬停即出、点按可钉住。
+ */
+export function PingTaskStatsPopover({ stat }: { stat: PingTaskStatSummary }) {
+  const fineHover = useFineHover();
+  const { open, position, triggerRef, surfaceRef, openOnHover, scheduleClose, togglePinned } =
+    useAnchoredPopover<HTMLButtonElement, HTMLDivElement>({
+      fallbackWidth: POPOVER_WIDTH,
+    });
+
+  const rows: Array<[string, string, string?]> = [
+    ["当前", formatMs(stat.latest)],
+    ["均值", formatMs(stat.avg)],
+    ["最低", formatMs(stat.min)],
+    ["最高", formatMs(stat.max)],
+    ["P50", formatMs(stat.p50)],
+    ["P99", formatMs(stat.p99)],
+    ["抖动", stat.volatility == null ? "—" : stat.volatility.toFixed(2)],
+    ["丢包", `${stat.loss.toFixed(1)}%`, lossHeatColor(stat.loss)],
+    ["样本", `${stat.lost} / ${stat.total}`],
+  ];
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="instance-ping-task-info"
+        aria-label={`${stat.name} 线路统计`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={togglePinned}
+        onPointerEnter={fineHover ? openOnHover : undefined}
+        onPointerLeave={fineHover ? scheduleClose : undefined}
+      >
+        <Info size={12} strokeWidth={2.2} aria-hidden />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={surfaceRef}
+            className="instance-ping-stats-popover"
+            role="dialog"
+            aria-label={`${stat.name} 线路统计`}
+            style={
+              position
+                ? { top: position.top, left: position.left }
+                : { top: 0, left: 0, visibility: "hidden" }
+            }
+            onPointerEnter={fineHover ? openOnHover : undefined}
+            onPointerLeave={fineHover ? scheduleClose : undefined}
+          >
+            <div className="instance-ping-stats-head">
+              <span className="instance-ping-stats-name">{stat.name}</span>
+              <span className="instance-ping-stats-meta">
+                {stat.type.toUpperCase()} · {stat.interval}s
+              </span>
+            </div>
+            {stat.target && (
+              <div className="instance-ping-stats-target" title={stat.target}>
+                {stat.target}
+              </div>
+            )}
+            <dl className="instance-ping-stats-rows">
+              {rows.map(([label, value, color]) => (
+                <div key={label} className="instance-ping-stats-row">
+                  <dt>{label}</dt>
+                  <dd className="tabular" style={color ? { color } : undefined}>
+                    {value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/components/instance/__tests__/chartZoom.test.ts
+++ b/src/components/instance/__tests__/chartZoom.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampZoomWindow,
+  FULL_ZOOM_WINDOW,
+  isFullZoomWindow,
+  panZoomWindow,
+  rangeToZoomWindow,
+  zoomWindowIndexRange,
+  zoomWindowToRange,
+} from "@/components/instance/chartZoom";
+
+describe("clampZoomWindow", () => {
+  it("把反向拖出来的窗口摆正", () => {
+    expect(clampZoomWindow({ start: 0.8, end: 0.2 })).toEqual({ start: 0.2, end: 0.8 });
+  });
+
+  it("过窄的窗口以中点为锚展开到最小宽度", () => {
+    const window = clampZoomWindow({ start: 0.5, end: 0.5 });
+
+    expect(window.end - window.start).toBeCloseTo(0.02, 10);
+    expect((window.start + window.end) / 2).toBeCloseTo(0.5, 10);
+  });
+
+  it("贴边的过窄窗口向内展开而不越界", () => {
+    expect(clampZoomWindow({ start: 0, end: 0.001 })).toEqual({ start: 0, end: 0.02 });
+    expect(clampZoomWindow({ start: 0.999, end: 1 })).toEqual({ start: 0.98, end: 1 });
+  });
+
+  it("非有限值退回全量窗口", () => {
+    expect(clampZoomWindow({ start: Number.NaN, end: 1 })).toEqual(FULL_ZOOM_WINDOW);
+  });
+});
+
+describe("zoomWindowToRange / rangeToZoomWindow", () => {
+  it("比例与绝对区间可以来回换算", () => {
+    const full: [number, number] = [1000, 2000];
+    const window = { start: 0.25, end: 0.75 };
+
+    expect(zoomWindowToRange(full, window)).toEqual([1250, 1750]);
+    expect(rangeToZoomWindow(full, [1250, 1750])).toEqual(window);
+  });
+
+  it("零宽的完整轴不做换算", () => {
+    expect(zoomWindowToRange([500, 500], { start: 0.2, end: 0.4 })).toEqual([500, 500]);
+    expect(rangeToZoomWindow([500, 500], [500, 500])).toEqual(FULL_ZOOM_WINDOW);
+  });
+});
+
+describe("panZoomWindow", () => {
+  it("平移时保持窗口宽度", () => {
+    const window = panZoomWindow({ start: 0.2, end: 0.4 }, 0.1);
+
+    expect(window.start).toBeCloseTo(0.3, 10);
+    expect(window.end).toBeCloseTo(0.5, 10);
+  });
+
+  it("碰到两端贴边停住而不压缩宽度", () => {
+    const atStart = panZoomWindow({ start: 0.2, end: 0.4 }, -1);
+    const atEnd = panZoomWindow({ start: 0.6, end: 0.8 }, 1);
+
+    expect(atStart.start).toBe(0);
+    expect(atStart.end).toBeCloseTo(0.2, 10);
+    expect(atEnd.start).toBeCloseTo(0.8, 10);
+    expect(atEnd.end).toBe(1);
+  });
+});
+
+describe("isFullZoomWindow", () => {
+  it("识别全量窗口", () => {
+    expect(isFullZoomWindow(FULL_ZOOM_WINDOW)).toBe(true);
+    expect(isFullZoomWindow({ start: 0, end: 0.9 })).toBe(false);
+  });
+});
+
+describe("zoomWindowIndexRange", () => {
+  it("返回落在区间内的首尾下标", () => {
+    expect(zoomWindowIndexRange([10, 20, 30, 40, 50], [20, 40])).toEqual({
+      fromIndex: 1,
+      toIndex: 3,
+    });
+  });
+
+  it("区间内没有点时返回空区间", () => {
+    expect(zoomWindowIndexRange([10, 20], [100, 200])).toEqual({
+      fromIndex: 0,
+      toIndex: -1,
+    });
+    expect(zoomWindowIndexRange([], [0, 1])).toEqual({ fromIndex: 0, toIndex: -1 });
+  });
+});

--- a/src/components/instance/__tests__/pingChartOverlay.test.ts
+++ b/src/components/instance/__tests__/pingChartOverlay.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildPingSeriesOverlay } from "@/components/instance/pingChartOverlay";
+
+describe("buildPingSeriesOverlay", () => {
+  it("只把 null 当丢包，跨过 off-phase 的 undefined", () => {
+    const overlay = buildPingSeriesOverlay([10, null, undefined, 20, null], "#f00");
+
+    expect(overlay.lossIndices).toEqual([1, 4]);
+    expect(overlay.max).toEqual({ index: 3, value: 20 });
+    expect(overlay.min).toEqual({ index: 0, value: 10 });
+  });
+
+  it("把 0ms 当有效的亚毫秒探测而非缺失", () => {
+    const overlay = buildPingSeriesOverlay([0, 5], "#f00");
+
+    expect(overlay.min).toEqual({ index: 0, value: 0 });
+    expect(overlay.lossIndices).toEqual([]);
+  });
+
+  it("极值落在同一点时只保留 max，避免两个 pin 重叠", () => {
+    const overlay = buildPingSeriesOverlay([undefined, 7, undefined], "#f00");
+
+    expect(overlay.max).toEqual({ index: 1, value: 7 });
+    expect(overlay.min).toBeNull();
+  });
+
+  it("几乎全丢时抑制竖线，避免绘图区被涂满", () => {
+    const values = Array.from({ length: 20 }, () => null);
+
+    expect(buildPingSeriesOverlay(values, "#f00").lossIndices).toEqual([]);
+  });
+
+  it("样本过少时不启用抑制，单次丢包仍要画出来", () => {
+    const overlay = buildPingSeriesOverlay([null], "#f00");
+
+    expect(overlay.lossIndices).toEqual([0]);
+  });
+
+  it("限定区间时只统计区间内的点", () => {
+    const overlay = buildPingSeriesOverlay([999, null, 10, 50, null, 1], "#f00", {
+      fromIndex: 2,
+      toIndex: 4,
+    });
+
+    expect(overlay.lossIndices).toEqual([4]);
+    expect(overlay.max).toEqual({ index: 3, value: 50 });
+    expect(overlay.min).toEqual({ index: 2, value: 10 });
+  });
+});

--- a/src/components/instance/__tests__/pingChartOverlayDraw.test.ts
+++ b/src/components/instance/__tests__/pingChartOverlayDraw.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type uPlot from "uplot";
+import {
+  buildPingSeriesOverlay,
+  drawPingOverlay,
+  type PingSeriesOverlay,
+} from "@/components/instance/pingChartOverlay";
+
+interface CanvasCall {
+  method: string;
+  args: unknown[];
+}
+
+interface TrackedCanvasState {
+  globalAlpha: number;
+  lineWidth: number;
+  strokeStyle: string;
+  fillStyle: string;
+  font: string;
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
+}
+
+const INITIAL_CANVAS_STATE: TrackedCanvasState = {
+  globalAlpha: 1,
+  lineWidth: 1,
+  strokeStyle: "",
+  fillStyle: "",
+  font: "",
+  textAlign: "start",
+  textBaseline: "alphabetic",
+};
+
+// save/restore 必须真的还原绘制状态，否则「透明度有没有泄漏」这类断言测的是 double 自己。
+function fakeContext() {
+  const calls: CanvasCall[] = [];
+  const stack: TrackedCanvasState[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const ctx = {
+    ...INITIAL_CANVAS_STATE,
+    calls,
+    save() {
+      calls.push({ method: "save", args: [] });
+      stack.push({
+        globalAlpha: ctx.globalAlpha,
+        lineWidth: ctx.lineWidth,
+        strokeStyle: ctx.strokeStyle,
+        fillStyle: ctx.fillStyle,
+        font: ctx.font,
+        textAlign: ctx.textAlign,
+        textBaseline: ctx.textBaseline,
+      });
+    },
+    restore() {
+      calls.push({ method: "restore", args: [] });
+      const snapshot = stack.pop();
+      if (snapshot) Object.assign(ctx, snapshot);
+    },
+    beginPath: record("beginPath"),
+    closePath: record("closePath"),
+    rect: record("rect"),
+    clip: record("clip"),
+    moveTo: record("moveTo"),
+    lineTo: record("lineTo"),
+    arc: record("arc"),
+    stroke: record("stroke"),
+    fill: record("fill"),
+    fillText: record("fillText"),
+  };
+  return ctx;
+}
+
+// x 直接当像素用；y 翻转成「值越大越靠上」，与真实图表一致。
+function fakePlot(times: number[], ctx: ReturnType<typeof fakeContext>) {
+  return {
+    ctx,
+    data: [times] as unknown as uPlot.AlignedData,
+    bbox: { left: 0, top: 0, width: 400, height: 200 },
+    over: { clientWidth: 400 },
+    valToPos: (value: number, scaleKey: string) =>
+      scaleKey === "x" ? value : 200 - value,
+  } as unknown as uPlot;
+}
+
+function callsOf(ctx: ReturnType<typeof fakeContext>, method: string) {
+  return ctx.calls.filter((call) => call.method === method);
+}
+
+describe("drawPingOverlay", () => {
+  const times = [0, 10, 20, 30];
+
+  it("为每个丢包点画一条竖线", () => {
+    const ctx = fakeContext();
+    const overlay = buildPingSeriesOverlay([5, null, 8, null], "#f00");
+
+    drawPingOverlay(fakePlot(times, ctx), [overlay], {
+      showLossLines: true,
+      showExtremePins: false,
+    });
+
+    const moves = callsOf(ctx, "moveTo");
+    expect(moves).toHaveLength(2);
+    expect(moves.map((call) => call.args[0])).toEqual([10.5, 30.5]);
+    expect(callsOf(ctx, "fillText")).toHaveLength(0);
+  });
+
+  it("为极值画出带取整数值的 pin", () => {
+    const ctx = fakeContext();
+    const overlay = buildPingSeriesOverlay([5.4, 120.6, 60, 30], "#f00");
+
+    drawPingOverlay(fakePlot(times, ctx), [overlay], {
+      showLossLines: false,
+      showExtremePins: true,
+    });
+
+    expect(callsOf(ctx, "fillText").map((call) => call.args[0])).toEqual(["121", "5"]);
+    expect(callsOf(ctx, "arc")).toHaveLength(2);
+  });
+
+  it("两项都关闭时不碰画布", () => {
+    const ctx = fakeContext();
+    const overlay = buildPingSeriesOverlay([5, null], "#f00");
+
+    drawPingOverlay(fakePlot(times, ctx), [overlay], {
+      showLossLines: false,
+      showExtremePins: false,
+    });
+
+    expect(ctx.calls).toHaveLength(0);
+  });
+
+  it("没有可见线路时不碰画布", () => {
+    const ctx = fakeContext();
+
+    drawPingOverlay(fakePlot(times, ctx), [] as PingSeriesOverlay[], {
+      showLossLines: true,
+      showExtremePins: true,
+    });
+
+    expect(ctx.calls).toHaveLength(0);
+  });
+
+  it("save/restore 成对出现，不把裁剪或透明度泄漏给后续绘制", () => {
+    const ctx = fakeContext();
+    const overlay = buildPingSeriesOverlay([5, null, 90], "#f00");
+
+    drawPingOverlay(fakePlot(times, ctx), [overlay], {
+      showLossLines: true,
+      showExtremePins: true,
+    });
+
+    expect(callsOf(ctx, "save")).toHaveLength(callsOf(ctx, "restore").length);
+    expect(callsOf(ctx, "clip")).toHaveLength(1);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+});

--- a/src/components/instance/chartZoom.ts
+++ b/src/components/instance/chartZoom.ts
@@ -1,0 +1,87 @@
+// 图表横向缩放窗口。以「占完整时间轴的比例」表达，而不是绝对时间戳：
+// 刷新拿到新数据、切换时间范围后，窗口仍然指向同一段相对区间，不需要重新换算。
+
+export interface ChartZoomWindow {
+  start: number;
+  end: number;
+}
+
+export type ChartRange = readonly [number, number];
+
+export const FULL_ZOOM_WINDOW: ChartZoomWindow = { start: 0, end: 1 };
+
+// 最窄可缩放到整段的 2%：再窄下去 uPlot 的 x scale 会退化成几乎零宽，
+// 坐标轴刻度和 tooltip 定位都会失真。
+const MIN_ZOOM_SPAN = 0.02;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function clampZoomWindow(window: ChartZoomWindow): ChartZoomWindow {
+  if (!Number.isFinite(window.start) || !Number.isFinite(window.end)) {
+    return FULL_ZOOM_WINDOW;
+  }
+  const start = clamp(Math.min(window.start, window.end), 0, 1);
+  const end = clamp(Math.max(window.start, window.end), 0, 1);
+  if (end - start >= MIN_ZOOM_SPAN) return { start, end };
+
+  // 宽度不足时以中点为锚展开到最小宽度，再整体推回 [0, 1] 内。
+  const center = (start + end) / 2;
+  const half = MIN_ZOOM_SPAN / 2;
+  if (center - half < 0) return { start: 0, end: MIN_ZOOM_SPAN };
+  if (center + half > 1) return { start: 1 - MIN_ZOOM_SPAN, end: 1 };
+  return { start: center - half, end: center + half };
+}
+
+export function isFullZoomWindow(window: ChartZoomWindow): boolean {
+  return window.start <= 0 && window.end >= 1;
+}
+
+export function zoomWindowToRange(
+  full: ChartRange,
+  window: ChartZoomWindow,
+): [number, number] {
+  const span = full[1] - full[0];
+  if (!(span > 0)) return [full[0], full[1]];
+  return [full[0] + span * window.start, full[0] + span * window.end];
+}
+
+export function rangeToZoomWindow(
+  full: ChartRange,
+  range: ChartRange,
+): ChartZoomWindow {
+  const span = full[1] - full[0];
+  if (!(span > 0)) return FULL_ZOOM_WINDOW;
+  return clampZoomWindow({
+    start: (range[0] - full[0]) / span,
+    end: (range[1] - full[0]) / span,
+  });
+}
+
+/** 保持窗口宽度不变地平移；碰到两端就贴边停住。 */
+export function panZoomWindow(
+  window: ChartZoomWindow,
+  deltaRatio: number,
+): ChartZoomWindow {
+  const span = window.end - window.start;
+  const start = clamp(window.start + deltaRatio, 0, 1 - span);
+  return { start, end: start + span };
+}
+
+/** 把可见时间区间换算成数据下标区间，供覆盖层只统计屏幕上看得到的点。 */
+export function zoomWindowIndexRange(
+  times: ReadonlyArray<number>,
+  range: ChartRange,
+): { fromIndex: number; toIndex: number } {
+  if (times.length === 0) return { fromIndex: 0, toIndex: -1 };
+  let fromIndex = times.length;
+  let toIndex = -1;
+  for (let index = 0; index < times.length; index += 1) {
+    const time = times[index];
+    if (time < range[0] || time > range[1]) continue;
+    if (index < fromIndex) fromIndex = index;
+    toIndex = index;
+  }
+  return toIndex < 0 ? { fromIndex: 0, toIndex: -1 } : { fromIndex, toIndex };
+}

--- a/src/components/instance/pingChartOverlay.ts
+++ b/src/components/instance/pingChartOverlay.ts
@@ -1,0 +1,190 @@
+import type uPlot from "uplot";
+
+// PingChart 的 uPlot 覆盖层：丢包竖线 + 极值 pin。
+// 对齐数据里 null = 真实断点(丢包/中断)、undefined = off-phase 无采样，两者语义不同，
+// 只有 null 才是「这一刻探测失败」，才值得在图上立一条竖线。
+
+export type ChartSeriesValues = ReadonlyArray<number | null | undefined>;
+
+export interface PingExtremePoint {
+  index: number;
+  value: number;
+}
+
+export interface PingSeriesOverlay {
+  color: string;
+  lossIndices: number[];
+  max: PingExtremePoint | null;
+  min: PingExtremePoint | null;
+}
+
+export interface PingOverlayRange {
+  fromIndex: number;
+  toIndex: number;
+}
+
+// 丢包比例超过这个值就不画竖线：整段几乎全丢时逐点画会把绘图区涂成实色，
+// 反而什么都读不出来。哪吒面板的服务监控图同款处理(lossRate > 99 时清空 markLine)。
+const LOSS_MARK_SUPPRESS_RATIO = 0.99;
+// 样本太少时不启用上面的抑制，否则「唯一一次采样正好丢包」会被判成全丢而不画。
+const LOSS_MARK_SUPPRESS_MIN_SAMPLES = 10;
+
+export function buildPingSeriesOverlay(
+  values: ChartSeriesValues,
+  color: string,
+  range?: PingOverlayRange,
+): PingSeriesOverlay {
+  const fromIndex = Math.max(0, range?.fromIndex ?? 0);
+  const toIndex = Math.min(values.length - 1, range?.toIndex ?? values.length - 1);
+  const lossIndices: number[] = [];
+  let max: PingExtremePoint | null = null;
+  let min: PingExtremePoint | null = null;
+  let validCount = 0;
+
+  for (let index = fromIndex; index <= toIndex; index += 1) {
+    const value = values[index];
+    if (value === null) {
+      lossIndices.push(index);
+      continue;
+    }
+    // 0 是亚毫秒成功探测，负值不该出现在图数据里(上游已转成 null)，一并当作无效跳过。
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) continue;
+    validCount += 1;
+    if (max == null || value > max.value) max = { index, value };
+    if (min == null || value < min.value) min = { index, value };
+  }
+
+  const sampled = validCount + lossIndices.length;
+  const suppressLossMarks =
+    sampled >= LOSS_MARK_SUPPRESS_MIN_SAMPLES &&
+    lossIndices.length / sampled > LOSS_MARK_SUPPRESS_RATIO;
+
+  return {
+    color,
+    lossIndices: suppressLossMarks ? [] : lossIndices,
+    max,
+    // 极值相等时只保留 max，避免两个 pin 完全重叠在同一点上。
+    min: min != null && max != null && min.index === max.index ? null : min,
+  };
+}
+
+const LOSS_LINE_ALPHA = 0.42;
+const LOSS_LINE_WIDTH = 1;
+const PIN_RADIUS = 9;
+const PIN_TIP = 7;
+const PIN_FILL_ALPHA = 0.55;
+const PIN_FONT_SIZE = 8;
+
+function pinPath(
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  tipLength: number,
+  pointingDown: boolean,
+) {
+  const direction = pointingDown ? 1 : -1;
+  // 圆心到切点的夹角：让三角形两边正好贴着圆周，画出水滴形而不是「圆上挂个三角」。
+  const spread = Math.PI / 3;
+  const base = pointingDown ? Math.PI / 2 : -Math.PI / 2;
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, radius, base + spread, base - spread + Math.PI * 2);
+  ctx.lineTo(centerX, centerY + direction * (radius + tipLength));
+  ctx.closePath();
+}
+
+function drawPin(
+  ctx: CanvasRenderingContext2D,
+  point: { x: number; y: number },
+  value: number,
+  color: string,
+  ratio: number,
+  bbox: uPlot.BBox,
+  preferAbove: boolean,
+) {
+  const radius = PIN_RADIUS * ratio;
+  const tipLength = PIN_TIP * ratio;
+  const offset = radius + tipLength;
+  // 贴着绘图区边缘时把 pin 翻到点的另一侧，避免被裁掉只剩半个气泡。
+  const fitsAbove = point.y - offset - radius >= bbox.top;
+  const fitsBelow = point.y + offset + radius <= bbox.top + bbox.height;
+  const above = preferAbove ? fitsAbove || !fitsBelow : fitsAbove && !fitsBelow;
+  const centerY = above ? point.y - offset : point.y + offset;
+
+  ctx.save();
+  ctx.globalAlpha = PIN_FILL_ALPHA;
+  ctx.fillStyle = color;
+  pinPath(ctx, point.x, centerY, radius, tipLength, above);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#ffffff";
+  ctx.font = `600 ${PIN_FONT_SIZE * ratio}px system-ui, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(String(Math.round(value)), point.x, centerY);
+  ctx.restore();
+}
+
+/** 在 uPlot 的 draw hook 中调用：先画丢包竖线垫底，再画极值 pin 压在最上层。 */
+export function drawPingOverlay(
+  u: uPlot,
+  overlays: readonly PingSeriesOverlay[],
+  options: { showLossLines: boolean; showExtremePins: boolean },
+) {
+  if (overlays.length === 0) return;
+  if (!options.showLossLines && !options.showExtremePins) return;
+
+  const ctx = u.ctx;
+  const times = u.data[0];
+  const ratio = u.bbox.width / Math.max(1, u.over.clientWidth);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
+  ctx.clip();
+
+  if (options.showLossLines) {
+    ctx.lineWidth = LOSS_LINE_WIDTH * ratio;
+    for (const overlay of overlays) {
+      ctx.save();
+      ctx.globalAlpha = LOSS_LINE_ALPHA;
+      ctx.strokeStyle = overlay.color;
+      ctx.beginPath();
+      for (const index of overlay.lossIndices) {
+        const time = times[index];
+        if (typeof time !== "number") continue;
+        const x = Math.round(u.valToPos(time, "x", true)) + 0.5;
+        ctx.moveTo(x, u.bbox.top);
+        ctx.lineTo(x, u.bbox.top + u.bbox.height);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+
+  if (options.showExtremePins) {
+    for (const overlay of overlays) {
+      for (const extreme of [overlay.max, overlay.min]) {
+        if (!extreme) continue;
+        const time = times[extreme.index];
+        if (typeof time !== "number") continue;
+        drawPin(
+          ctx,
+          {
+            x: u.valToPos(time, "x", true),
+            y: u.valToPos(extreme.value, "y", true),
+          },
+          extreme.value,
+          overlay.color,
+          ratio,
+          u.bbox,
+          extreme === overlay.max,
+        );
+      }
+    }
+  }
+
+  ctx.restore();
+}

--- a/src/hooks/useAnchoredPopover.ts
+++ b/src/hooks/useAnchoredPopover.ts
@@ -1,0 +1,139 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+import {
+  INITIAL_NODE_TODAY_TRAFFIC_POPOVER_STATE,
+  isNodeTodayTrafficPopoverOpen,
+  nodeTodayTrafficPopoverReducer,
+} from "@/components/node/nodeTodayTrafficPopoverState";
+
+const POPOVER_GAP = 8;
+const VIEWPORT_PADDING = 8;
+const HOVER_CLOSE_DELAY_MS = 160;
+
+export interface AnchoredPopoverPosition {
+  top: number;
+  left: number;
+}
+
+/**
+ * 锚定在触发元素上的浮层：桌面悬停、触屏点按，位置随视口翻转并收敛到边界内，
+ * 打开期间点击外部 / Esc / 滚动 / 缩放都会关闭。
+ *
+ * 开关状态机复用 NodeTodayTrafficPopover 那套 hover/pinned/focus 三态 reducer——
+ * 它本身与「今日流量」无关，是纯粹的浮层开关语义。
+ */
+export function useAnchoredPopover<
+  Trigger extends HTMLElement,
+  Surface extends HTMLElement,
+>({ fallbackWidth }: { fallbackWidth: number }) {
+  const triggerRef = useRef<Trigger>(null);
+  const surfaceRef = useRef<Surface>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  const [state, dispatch] = useReducer(
+    nodeTodayTrafficPopoverReducer,
+    INITIAL_NODE_TODAY_TRAFFIC_POPOVER_STATE,
+  );
+  const [position, setPosition] = useState<AnchoredPopoverPosition | null>(null);
+  const open = isNodeTodayTrafficPopoverOpen(state);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const openOnHover = useCallback(() => {
+    cancelClose();
+    dispatch({ type: "hover-open" });
+  }, [cancelClose]);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(() => {
+      dispatch({ type: "hover-close" });
+    }, HOVER_CLOSE_DELAY_MS);
+  }, [cancelClose]);
+
+  const togglePinned = useCallback(() => {
+    cancelClose();
+    dispatch({ type: "toggle-pin" });
+  }, [cancelClose]);
+
+  useEffect(() => () => cancelClose(), [cancelClose]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const update = () => {
+      const rect = trigger.getBoundingClientRect();
+      const width = surfaceRef.current?.offsetWidth || fallbackWidth;
+      const height = surfaceRef.current?.offsetHeight ?? 0;
+      const belowTop = rect.bottom + POPOVER_GAP;
+      const top =
+        belowTop + height > window.innerHeight - VIEWPORT_PADDING
+          ? Math.max(VIEWPORT_PADDING, rect.top - height - POPOVER_GAP)
+          : belowTop;
+      const left = Math.min(
+        Math.max(VIEWPORT_PADDING, rect.left + rect.width / 2 - width / 2),
+        Math.max(VIEWPORT_PADDING, window.innerWidth - width - VIEWPORT_PADDING),
+      );
+      setPosition({ top, left });
+    };
+    update();
+    // 首帧浮层还没测量到真实尺寸，下一帧用实际宽高再定位一次。
+    const frame = window.requestAnimationFrame(update);
+    return () => window.cancelAnimationFrame(frame);
+  }, [fallbackWidth, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeAll = () => {
+      cancelClose();
+      dispatch({ type: "close-all" });
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (
+        target &&
+        (triggerRef.current?.contains(target) || surfaceRef.current?.contains(target))
+      ) {
+        return;
+      }
+      closeAll();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeAll();
+    };
+    window.addEventListener("resize", closeAll);
+    window.addEventListener("scroll", closeAll, { capture: true, passive: true });
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("resize", closeAll);
+      window.removeEventListener("scroll", closeAll, { capture: true });
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [cancelClose, open]);
+
+  return {
+    open,
+    position,
+    triggerRef,
+    surfaceRef,
+    openOnHover,
+    scheduleClose,
+    togglePinned,
+  };
+}

--- a/src/styles/surface.css
+++ b/src/styles/surface.css
@@ -1604,9 +1604,8 @@ body::after {
 .instance-ping-task {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
   min-width: 0;
-  padding: 5px 11px;
+  padding: 0 4px 0 0;
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
   background: color-mix(in srgb, var(--surface-elev) 92%, transparent);
@@ -1616,6 +1615,47 @@ body::after {
   text-align: left;
   white-space: nowrap;
   transition: opacity 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+/* chip 主体负责切换线路显隐；统计入口是它旁边的独立按钮，
+   两者必须是兄弟节点——button 不能嵌套 button。 */
+.instance-ping-task-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 5px 6px 5px 11px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.instance-ping-task-main:focus-visible,
+.instance-ping-task-info:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.instance-ping-task-info {
+  display: inline-grid;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-tertiary);
+  transition: color 160ms ease, background 160ms ease;
+}
+
+.instance-ping-task-info:hover,
+.instance-ping-task-info[aria-expanded="true"] {
+  background: var(--fill-tertiary);
+  color: var(--text-primary);
 }
 
 .instance-ping-task-dot {
@@ -1647,6 +1687,182 @@ body::after {
 
 .instance-ping-task[data-visible="false"] {
   opacity: 0.4;
+}
+
+/* 线路统计浮层：原先这些数字塞在原生 title 里，触屏完全看不到。 */
+.instance-ping-stats-popover {
+  position: fixed;
+  z-index: 90;
+  width: 208px;
+  padding: 11px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-elev-a) 96%, transparent);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.45;
+  animation: instance-ping-stats-in 120ms ease;
+}
+
+@keyframes instance-ping-stats-in {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .instance-ping-stats-popover {
+    animation: none;
+  }
+}
+
+.instance-ping-stats-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.instance-ping-stats-name {
+  min-width: 0;
+  overflow: hidden;
+  font-weight: 680;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.instance-ping-stats-meta {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  font-weight: 600;
+}
+
+.instance-ping-stats-target {
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--hairline);
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.instance-ping-stats-rows {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px 12px;
+  margin: 0;
+}
+
+.instance-ping-stats-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.instance-ping-stats-row dt {
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
+.instance-ping-stats-row dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+/* 横向缩放条：缩略曲线打底，窗口色块和两个把手浮在上面。 */
+.instance-range-slider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.instance-range-slider-track {
+  position: relative;
+  flex: 1 1 auto;
+  height: 40px;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface-elev) 82%, transparent);
+  touch-action: none;
+}
+
+.instance-range-slider-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.instance-range-slider-window {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid var(--border-strong);
+  border-right: 1px solid var(--border-strong);
+  background: color-mix(in srgb, var(--ring) 14%, transparent);
+  cursor: grab;
+}
+
+.instance-range-slider-window:active {
+  cursor: grabbing;
+}
+
+.instance-range-slider-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: ew-resize;
+}
+
+.instance-range-slider-handle::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--text-tertiary);
+  transform: translate(-50%, -50%);
+}
+
+/* 把手贴在窗口内侧而非跨在边界上：track 会裁掉溢出部分，
+   窗口拖到两端时把手仍然完整可见、可点。 */
+.instance-range-slider-handle.is-start {
+  left: 0;
+}
+
+.instance-range-slider-handle.is-end {
+  right: 0;
+}
+
+.instance-range-slider-reset {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 720px) {
+  .instance-range-slider-track {
+    height: 32px;
+  }
 }
 
 .instance-empty {


### PR DESCRIPTION
对标哪吒面板服务监控图，在现有 uPlot 图表上补四项标注能力，
不引入 ECharts，与主题其余图表共用 chartShared 的配色与 tooltip。

- 丢包竖线：探测失败(null)的时刻画同色半透明竖线；只认 null， 跳过多任务错相采样留下的 undefined。丢包率 >99% 且样本足够时 自动抑制，避免整块绘图区被涂实。
- 极值 pin：每条线可见区间的最高/最低点标出数值气泡， 贴近绘图区边缘时自动翻到数据点另一侧，不被裁切。
- tooltip 补丢包率：行格式改为「名称 丢包%: 延迟 ms」。
- 横向缩放条：缩略曲线打底 + 双把手 + 拖动平移 + 恢复全部； y 轴跟随可见区间重算。缩放窗口是唯一数据源，图上拖拽选区经 setSelect 换算回同一窗口(关闭 uPlot 自带 setScale 缩放)， 区间与覆盖层走 ref 下发，拖动时不重建图表。

图例统计从原生 title 迁到受控浮层，悬停即出、触屏可点按钉住，
展示当前/均值/min/max/P50/P99/抖动/丢包/样本。